### PR TITLE
linux-firmware: add support for intel ax200 and 9260 chips

### DIFF
--- a/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -1,0 +1,7 @@
+CONNECTIVITY_FIRMWARES:append = " \
+    linux-firmware-iwlwifi-cc-a0 \
+    linux-firmware-iwlwifi-9260 \
+    linux-firmware-ibt-18-16-1 \
+    linux-firmware-ibt-12-16 \
+    linux-firmware-ibt-20-1-3 \
+    "

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,7 @@
+# required to support verification hardware.
+PACKAGES =+ "${PN}-ibt-20-1-3"
+
+FILES:${PN}-ibt-20-1-3  = " \
+    ${nonarch_base_libdir}/firmware/intel/ibt-20-1-3.ddc* \
+    ${nonarch_base_libdir}/firmware/intel/ibt-20-1-3.sfi* \
+    "


### PR DESCRIPTION
Also add ibt-20 bluetooth support for device used during verification.